### PR TITLE
Update properties.json

### DIFF
--- a/com.ibi.odometer/properties.json
+++ b/com.ibi.odometer/properties.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"version": 1.0,
+		"version": 1.1,
 		"implements_api_version": 2.0,
 		"author": "Cloud Software Group, Inc.",
 		"copyright": "Cloud Software Group, Inc.",


### PR DESCRIPTION
When using the Odometer custom graph in Designer, switching the Animation Style of the Extension Properties from Spin to Count causes the text size to appear small in the preview screen and works in runtime