### PR TITLE
Update properties.json

### DIFF
--- a/com.ibi.corona/properties.json
+++ b/com.ibi.corona/properties.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"version": 1.3,
+		"version": 1.4,
 		"implements_api_version": 2.0,
 		"author": "Cloud Software Group, Inc.",
 		"copyright": "Cloud Software Group, Inc.",


### PR DESCRIPTION
VIZ-1208-Title: Corona Chart Heading and Footing Not Applied

Updated version in properties.json